### PR TITLE
Apache Version 2.0 license header

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ We ship with a few blue prints:
 
 * `camunda-licensed/mit`: ensures that all source files start with the [MIT license header](./resources/MIT-license-header.js)
 * `camunda-licensed/commercial`: ensures that all source files start with the [Camunda commercial license header](./resources/commercial-license-header.js)
+* `camunda-licensed/apache`: ensures that all source files start with the [Apache Version 2.0 license header](./resources/apache-license-header.js)
 
 
 ## Maintain Licenses

--- a/configs/apache.js
+++ b/configs/apache.js
@@ -1,0 +1,10 @@
+const path = require('path');
+
+module.exports = {
+  plugins: [
+    'license-header'
+  ],
+  rules: {
+    'license-header/header': [2, path.join(__dirname, '/../resources/apache-license-header.js') ]
+  }
+};

--- a/index.js
+++ b/index.js
@@ -2,11 +2,13 @@
 
 var mit = require('./configs/mit');
 var commercial = require('./configs/commercial');
+var apache = require('./configs/apache');
 
 module.exports = {
   configs: {
     mit,
     MIT: mit,
-    commercial
+    commercial,
+    apache
   }
 };

--- a/resources/apache-license-header.js
+++ b/resources/apache-license-header.js
@@ -1,0 +1,16 @@
+ /*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/test/apache/.eslintrc
+++ b/test/apache/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "plugin:camunda-licensed/apache"
+  ]
+}

--- a/test/apache/fix/no-license.js
+++ b/test/apache/fix/no-license.js
@@ -1,0 +1,6 @@
+/**
+ * I DO STUFF
+ */
+module.exports = function bar() {
+
+}

--- a/test/apache/fix/outdated-license.js
+++ b/test/apache/fix/outdated-license.js
@@ -1,0 +1,20 @@
+ /*
+ * Copyright camunda services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = function hello() {
+  return "HELLO";
+};

--- a/test/apache/valid/with-license.js
+++ b/test/apache/valid/with-license.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = function hello() {
+  return "HELLO";
+};

--- a/test/package.json
+++ b/test/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "test": "run-s lint fix",
-    "lint": "eslint mit/valid commercial/valid",
-    "fix": "eslint mit/fix commercial/fix --fix-dry-run"
+    "lint": "eslint mit/valid commercial/valid apache/valid",
+    "fix": "eslint mit/fix commercial/fix apache/fix --fix-dry-run"
   },
   "devDependencies": {
     "eslint": "^4.17.0",


### PR DESCRIPTION
This provides a Apache Version 2.0 license header. That I would like to use in the `camunda-bpm-webapps` projects.

@nikku, can you please review my PR?

Thanks.